### PR TITLE
[YPKCOY-304] Delete weird text in learn more.

### DIFF
--- a/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocModal.php
+++ b/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocModal.php
@@ -47,7 +47,7 @@ class HBLocModal extends HomeBranchLibraryBase {
         <h5>Why set your home branch?</h5>
         <p>Many YMCA members primarily visit one YMCA branch. Setting your home branch customizes your experience with schedules and programs for that branch. You are still able to view information for all other branches.</p>
         <h5>Changing your home branch</h5>
-        <p>You can change your home branch at any time by using the branch link at the top of the website. If we change the link in the header to go straight to the location page, we\'ll need to update the "Changing your home branch" copy – so lets wed these two tickets. </p>
+        <p>You can change your home branch at any time by using the branch link at the top of the website. </p>
       '),
     ];
   }


### PR DESCRIPTION
This PR is going to delete weird text (looks like some technical details) in the Home Branch popup's Learn more.

Steps for review:
- [ ] enable `Open Y Home Branch` module
- [ ] on any page in the `Home Branch` popup click Learn More https://i.imgur.com/ufu3Yuv.png
- [ ] make sure the weird text is not displayed https://i.imgur.com/QMkgng6.png