### PR TITLE
Rename OpenY admin menu to YMCA Website Services [YUOPENY-4]

### DIFF
--- a/openy_system/openy_system.routing.yml
+++ b/openy_system/openy_system.routing.yml
@@ -2,7 +2,7 @@ openy_system.openy_config:
   path: '/admin/openy'
   defaults:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
-    _title: 'Open Y'
+    _title: 'YMCA Website Services'
   requirements:
     _permission: 'access administration pages'
 


### PR DESCRIPTION
This PR simply renames admin menu item from Open Y to YMCA Website Services [work item #31517]

Steps for review:
 - [ ] setup OpenY
 - [ ] login as admin
 - [ ] admin menu item for OpenY settings should read **YMCA Website Services**