### PR TITLE
DS-101 fix: Flush all caches to update module location

### DIFF
--- a/openy_system/openy_system.install
+++ b/openy_system/openy_system.install
@@ -15,3 +15,17 @@ function openy_system_update_8001() {
   $role->grantPermission('use all drupal themes');
   $role->save();
 }
+
+/**
+ * Deep cache clear so that Drupal recognizes profile and module path changes.
+ */
+function openy_system_update_8002() {
+  drupal_flush_all_caches();
+}
+
+/**
+ * Enable admin_toolbar_tools module.
+ */
+function openy_system_update_8003() {
+  \Drupal::service('module_installer')->install(['admin_toolbar_tools']);
+}


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-101

Cache clear needs to happen in a module instead of a profile, as per [this issue](https://www.drupal.org/project/drupal/issues/2982052)

> Install hooks in profiles were so far only called when a site was installed...

Also moving https://github.com/YCloudYUSA/yusaopeny/pull/22 so that it takes effect for existing sites.