### PR TITLE
fix: https://www.drupal.org/node/3225357 findConfigEntityDependentsAsEntities now findConfigEntityDependenciesAsEntities

### DIFF
--- a/openy_system/src/OpenyModulesManager.php
+++ b/openy_system/src/OpenyModulesManager.php
@@ -280,7 +280,7 @@ class OpenyModulesManager {
       return;
     }
     // Get config entities that are dependent on module.
-    $dependencies = $this->configManager->findConfigEntityDependentsAsEntities('module', (array) $module_name);
+    $dependencies = $this->configManager->findConfigEntityDependenciesAsEntities('module', (array) $module_name);
     // Create array of dependent migrations for module.
     // That module should be listed in dependencies of migration config.
     foreach ($dependencies as $dependency) {


### PR DESCRIPTION
Addresses: https://www.drupal.org/node/3225357
Fixes: https://github.com/YCloudYUSA/yusaopeny/pull/8#issuecomment-1521206475
