### PR TITLE
fix: Accordion items don't take focus

### DIFF
--- a/openy_field_faq/templates/openy-faq-item.html.twig
+++ b/openy_field_faq/templates/openy-faq-item.html.twig
@@ -13,9 +13,9 @@
  */
 #}
 <div class="paragraph--type--faq-item conceal">
-  <div class="field-question">
+  <button class="field-question">
     {{- question -}}
-  </div>
+  </button>
   <div class="field-answer clearfix">
     {{- answer -}}
   </div>


### PR DESCRIPTION
This template is overridden in themes, but changing the base here in case it isn't. See [opey_carnation on drupal.org](https://git.drupalcode.org/issue/openy_carnation-3372019/-/commit/b93b923818c8b28ab4f79cb68f33c74fb3c505da) for a full fix with Bootstrap classes that retain styling.