### PR TITLE
DS-863 fix: Remove close behavior to let Bootstrap do its thing

### DIFF
--- a/openy_calc/js/openy_calc.js
+++ b/openy_calc/js/openy_calc.js
@@ -14,16 +14,4 @@
       });
     }
   };
-
-  /**
-   * To close the alert Modals dialog.
-   */
-  Drupal.behaviors.openyAlertModalsClose = {
-    attach: function (context, settings) {
-      $('.alert-modal .close').on('click', function (e) {
-        e.preventDefault();
-        $(this).closest('.alert-modal').remove();
-      });
-    }
-  };
 })(jQuery);


### PR DESCRIPTION
[DS-863](https://yusa.atlassian.net/browse/DS-863) This custom JS is overriding the Bootstrap-native hooks on the modal that was not getting fully instantiated before https://www.drupal.org/project/openy_carnation/issues/3374507 was closed. This removes the custom handler so that click AND keyboard can properly close the modal and return to the proper state. 