### PR TITLE
Remove context from openy_calc_scroll behaviour.

### DIFF
--- a/openy_calc/js/openy_calc_submit.js
+++ b/openy_calc/js/openy_calc_submit.js
@@ -9,10 +9,9 @@
    */
   Drupal.behaviors.openy_calc_scroll = {
     attach: function (context, settings) {
-      $(once('openy-calc-scroll', '#membership-calc-wrapper', context))
-        .each(function () {
-          var divPosition = $(this).offset();
-          $('html, body').animate({scrollTop: divPosition.top - 100}, "slow");
+      once('openy-calc-scroll', '#membership-calc-wrapper').forEach((wrapper) => {
+        var divPosition = $(wrapper).offset();
+        $('html, body').animate({scrollTop: divPosition.top - 100}, "slow");
       });
     }
   };


### PR DESCRIPTION
The scroll to top behaviour is not working when clicking "Next" on the Membership Calculator.

This happens because `once('openy-calc-scroll', '#membership-calc-wrapper', context)` returns `[]` when `context` has a `<div id="membership-calc-wrapper"></div>` as a root element. We get this when the form is rebuilt and returned via AJAX.

The PR is aimed to remove the usage of the `context`. 