### PR TITLE
Allow plugin definitions caching

### DIFF
--- a/openy_home_branch/src/HomeBranchLibraryManager.php
+++ b/openy_home_branch/src/HomeBranchLibraryManager.php
@@ -31,8 +31,7 @@ class HomeBranchLibraryManager extends DefaultPluginManager {
     );
 
     $this->alterInfo('home_branch_library_info');
-    $this->setCacheBackend($cache_backend, 'home_branch_library', ['node_list']);
-    $this->factory = new ContainerFactory($this->getDiscovery());
+    $this->setCacheBackend($cache_backend, 'home_branch_library');
   }
 
   /**


### PR DESCRIPTION
The custom ContainerFactory assigned upon instantiating the HomeBranch plugin manager disables the plugin definition caching. That leads to a performance issue - Drupal core searches for the plugins each time the plugin is requested.

On one of the websites, the Plugin Discovery during the content indexing could call the `file_exists` function and annotation reading 50k times for 50 indexed nodes.

Also, the cache backend doesn't need its entries to be tagged with 'node_list', because a change in nodes can't change the plugin definitions.