### PR TITLE
DS-280 Cross-domain tracking (part 2)

### DIFF
--- a/openy_xdt/config/install/openy_xdt.settings.yml
+++ b/openy_xdt/config/install/openy_xdt.settings.yml
@@ -1,0 +1,3 @@
+cookies:
+  - _gl
+domains: {  }

--- a/openy_xdt/config/schema/openy_xdt.schema.yml
+++ b/openy_xdt/config/schema/openy_xdt.schema.yml
@@ -1,0 +1,19 @@
+# Schema for the configuration files of the YMCA Website Services Cross-domain Tracking (XDT) module.
+openy_xdt.settings:
+  type: config_object
+  label: 'YMCA Website Services Cross-domain Tracking (XDT) settings'
+  mapping:
+    cookies:
+      type: sequence
+      label: 'Cookies'
+      orderby: value
+      sequence:
+        type: string
+        label: 'Cookie'
+    domains:
+      type: sequence
+      label: 'Domains'
+      orderby: value
+      sequence:
+        type: string
+        label: 'Domain'

--- a/openy_xdt/openy_xdt.links.menu.yml
+++ b/openy_xdt/openy_xdt.links.menu.yml
@@ -1,5 +1,6 @@
 openy_xdt.settings:
-  title: Cross-domain Tracking Settings
+  title: Cross-domain tracking settings
   description: Configure cookies and domains to enable cross-domain tracking.
+  parent: openy_system.openy_settings
   route_name: openy_xdt.settings
   weight: 10

--- a/openy_xdt/openy_xdt.links.menu.yml
+++ b/openy_xdt/openy_xdt.links.menu.yml
@@ -1,0 +1,5 @@
+openy_xdt.settings:
+  title: Cross-domain Tracking Settings
+  description: Configure cookies and domains to enable cross-domain tracking.
+  route_name: openy_xdt.settings
+  weight: 10

--- a/openy_xdt/openy_xdt.module
+++ b/openy_xdt/openy_xdt.module
@@ -2,14 +2,15 @@
 
 /**
  * @file
- * Primary module hooks for YMCA Website Services Cross-domain Tracking (XDT) module.
+ * Primary module hooks for YMCA Website Services Cross-domain Tracking (XDT).
  */
+
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_help().
  */
-function openy_xdt_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match)
-{
+function openy_xdt_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name == 'help.page.openy_xdt' || $route_name == 'openy_xdt.settings') {
     $help = '<p>' . t('This configuration enables cross-domain tracking to work through internal redirects in addition to regular links. Configuration and testing of analytics is outside the scope of this module, refer to <a href="@analytics-help" target="_blank">[GA4] Set up cross-domain measurement</a> for more information.',
         ['@analytics-help' => 'https://support.google.com/analytics/answer/10071811?hl=en']) . '</p>';

--- a/openy_xdt/openy_xdt.module
+++ b/openy_xdt/openy_xdt.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for YMCA Website Services Cross-domain Tracking (XDT) module.
+ */
+
+/**
+ * Implements hook_help().
+ */
+function openy_xdt_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match)
+{
+  if ($route_name == 'help.page.openy_xdt' || $route_name == 'openy_xdt.settings') {
+    $help = '<p>' . t('This configuration enables cross-domain tracking to work through internal redirects in addition to regular links. Configuration and testing of analytics is outside the scope of this module, refer to <a href="@analytics-help" target="_blank">[GA4] Set up cross-domain measurement</a> for more information.',
+        ['@analytics-help' => 'https://support.google.com/analytics/answer/10071811?hl=en']) . '</p>';
+    $help .= '<p>' . t('When enabled, cookies matching any configured tag will be added to any redirect destination matching a configured domain. For example, a redirect to <code>https://example.com</code> will be transformed to <code>https://example.com/?_gl=...</code>.');
+
+    return $help;
+  }
+}

--- a/openy_xdt/openy_xdt.routing.yml
+++ b/openy_xdt/openy_xdt.routing.yml
@@ -1,0 +1,7 @@
+openy_xdt.settings:
+  path: '/admin/openy/settings/xdt-settings'
+  defaults:
+    _title: 'Cross-domain Tracking Settings'
+    _form: 'Drupal\openy_xdt\Form\SettingsForm'
+  requirements:
+    _permission: 'administer site configuration'

--- a/openy_xdt/openy_xdt.routing.yml
+++ b/openy_xdt/openy_xdt.routing.yml
@@ -1,5 +1,5 @@
 openy_xdt.settings:
-  path: '/admin/openy/settings/xdt-settings'
+  path: '/admin/openy/settings/xdt'
   defaults:
     _title: 'Cross-domain Tracking Settings'
     _form: 'Drupal\openy_xdt\Form\SettingsForm'

--- a/openy_xdt/openy_xdt.services.yml
+++ b/openy_xdt/openy_xdt.services.yml
@@ -1,5 +1,6 @@
 services:
   openy_xdt.event_subscriber:
     class: Drupal\openy_xdt\EventSubscriber\OpenyXdtSubscriber
+    arguments: [ '@config.factory' ]
     tags:
       - { name: event_subscriber }

--- a/openy_xdt/src/EventSubscriber/OpenyXdtSubscriber.php
+++ b/openy_xdt/src/EventSubscriber/OpenyXdtSubscriber.php
@@ -16,12 +16,17 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class OpenyXdtSubscriber implements EventSubscriberInterface {
 
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
   protected $configFactory;
 
   /**
    * Constructor so we can read configuration.
    *
-   * @param ConfigFactoryInterface $config_factory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
@@ -31,7 +36,7 @@ class OpenyXdtSubscriber implements EventSubscriberInterface {
   /**
    * Kernel response event handler.
    *
-   * @param ResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   Response event.
    */
   public function onKernelResponse(ResponseEvent $event) {
@@ -44,7 +49,7 @@ class OpenyXdtSubscriber implements EventSubscriberInterface {
       $domains = $config->get('domains');
 
       // Get the destination url.
-      /* @var $response TrustedRedirectResponse */
+      /** @var \Drupal\Core\Routing\TrustedRedirectResponse $response */
       $response = $event->getResponse();
       $url = $response->getTargetUrl();
 
@@ -56,7 +61,8 @@ class OpenyXdtSubscriber implements EventSubscriberInterface {
         return;
       }
 
-      // If the domain matches the url host then merge any additional cookies into the query.
+      // If the domain matches the url host then merge any additional cookies
+      // into the query.
       foreach ($cookies as $cookie) {
         if (isset($_COOKIE[$cookie])) {
           $parts['query'][$cookie] = Xss::filter($_COOKIE[$cookie]);
@@ -66,7 +72,7 @@ class OpenyXdtSubscriber implements EventSubscriberInterface {
       // Finally recompose the URL and convert it back to a string.
       $newUrl = Url::fromUri($parts['path'], [
         'query' => $parts['query'],
-        'fragment' => $parts['fragment']
+        'fragment' => $parts['fragment'],
       ])->toString();
 
       // Pass the new URL back to the response.

--- a/openy_xdt/src/Form/SettingsForm.php
+++ b/openy_xdt/src/Form/SettingsForm.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\openy_xdt\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure YMCA Website Services Cross-domain Tracking (XDT) settings for this site.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_xdt_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['openy_xdt.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Both items are stored as arrays in config, so they need to be imploded to be displayed in the textarea.
+    $form['cookies'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Cookies'),
+      '#default_value' => implode(PHP_EOL, $this->config('openy_xdt.settings')->get('cookies') ?? []),
+      '#description' => $this->t('The cookies to transfer to the query string. One per line. If empty, no action will be taken.'),
+    ];
+    $form['domains'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Domains'),
+      '#default_value' => implode(PHP_EOL, $this->config('openy_xdt.settings')->get('domains') ?? []),
+      '#description' => $this->t('The destination domains that will have cookies added to the query string. One per line. If empty, no action will be taken.'),
+      '#placeholder' => 'www.example.com'
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // If domains are set, ensure they are valid.
+    if (!empty($form_state->getValue('domains'))) {
+      $domains = preg_split('/\R/', $form_state->getValue('domains'));
+      foreach ($domains as $domain) {
+        if (!empty($domain) && !filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
+          $form_state->setErrorByName('domain', $this->t('%domain is not a valid domain. Remove any slashes and only enter the part of the url between <em>https://</em> and the next <em>/</em>.', ['%domain' => $domain]));
+        }
+      }
+    }
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('openy_xdt.settings')
+      // Split values at line breaks and filter out any empty values.
+      ->set('cookies', array_filter(preg_split('/\R/', $form_state->getValue('cookies'))))
+      ->set('domains', array_filter(preg_split('/\R/', $form_state->getValue('domains'))))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/openy_xdt/src/Form/SettingsForm.php
+++ b/openy_xdt/src/Form/SettingsForm.php
@@ -6,7 +6,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Configure YMCA Website Services Cross-domain Tracking (XDT) settings for this site.
+ * Configure YMCA Website Services Cross-domain Tracking (XDT) settings.
  */
 class SettingsForm extends ConfigFormBase {
 
@@ -28,7 +28,8 @@ class SettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    // Both items are stored as arrays in config, so they need to be imploded to be displayed in the textarea.
+    // Both items are stored as arrays in config, so they need to be imploded
+    // to be displayed in the textarea.
     $form['cookies'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Cookies'),
@@ -40,7 +41,7 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('Domains'),
       '#default_value' => implode(PHP_EOL, $this->config('openy_xdt.settings')->get('domains') ?? []),
       '#description' => $this->t('The destination domains that will have cookies added to the query string. One per line. If empty, no action will be taken.'),
-      '#placeholder' => 'www.example.com'
+      '#placeholder' => 'www.example.com',
     ];
     return parent::buildForm($form, $form_state);
   }


### PR DESCRIPTION
Adds a config form at `admin/openy/settings/xdt` with two settings to configure Cookies and Domains for cross-domain tracking.

When a TrustedRedirectResponse contains a `domain` in the list, if any of the `cookies` set exist, their values will be pulled from storage and put into the query string before the user is redirected, allowing for successful cross-domain tracking on any application that uses TrustedRedirectResponse. Should work on Membership Calculator, Activity Finder, and more.

![Cross-domain_Tracking_Settings___YMCA_OF__SPRINGFIELD_](https://github.com/open-y-subprojects/openy_custom/assets/238201/e1db01fa-956c-4ad5-8016-2f2e4ab1c826)
