### PR TITLE
DS-1254 search config

### DIFF
--- a/openy_search/SMOKE_TESTS.md
+++ b/openy_search/SMOKE_TESTS.md
@@ -2,7 +2,7 @@
 
 In order for OpenY Search being tested in a short timeframe, please follow steps below
 
-# Component: Open Y Search								
+# Component: YMCA Website Services Search
 
 ## Enable/Hide Search form
 
@@ -12,19 +12,19 @@ Administrator
 
 ### Steps
 
-0. Verify you see a search icon in the header and it opens search form. 
-1. Log in as Admin 
-2. Go to Appearance -> Installed themes 
-3. Find ""Open Y Carnation"" and open settings 
+0. Verify you see a search icon in the header and it opens search form.
+1. Log in as Admin
+2. Go to Appearance -> Installed themes
+3. Find ""YMCA Website Services Carnation"" and open settings
 4. Verify there is a collapsible search fieldset and ""Display the search form"" checkbox
 5. Verify after enabling/disabling checkbox search icon and form appears/disappears from the header
 
 ### Expected Results
 
-1. There are settings in the Carnation theme to show/hide search form 
+1. There are settings in the Carnation theme to show/hide search form
 2. Settings work
 
-## Configure search using Apache Solr/Open Y search (Solr back-end)
+## Configure search using Apache Solr/YMCA Website Services search (Solr back-end)
 
 ### User
 
@@ -34,33 +34,33 @@ Administrator
 
 1. Login as Admin
 2. Go to Extend
-3. Install module ""Open Y Search API"" and all required modules
-4. Uninstall ""Open Y Google Search"" if it is installed.
+3. Install module ""YMCA Website Services Search API"" and all required modules
+4. Uninstall ""YMCA Website Services Google Search"" if it is installed.
 5. Make sure modules Search API, Search API Solr are installed
 6. Go to Configuration -> Search and metadata -> Search API (/admin/config/search/search-api)
 7. Verify you can see a server called ""Solr search"" disabled by default
 8. Enable this server using Operations
-9. Edit this server 
+9. Edit this server
 10. Modify Solr host field and enter there IP address (for builds and local env 127.0.0.1)
 11. Modify Solr core field and enter there the name that identifies the Solr core on the server (for example ""d9_sandbox_carnation_custom"")
 12. Save
 13. Verify solr server is working and there are no error messages
 14. On the Configuration -> Search and metadata -> Search API (/admin/config/search/search-api) page find index called ""Search Content""
-15. Open for editing ""Search Content"" index 
+15. Open for editing ""Search Content"" index
 16. Chose Server ""Solr search""
 17. Click on the Search Content link to open View page
 18. On the View page in the fieldsel called ""Start indexing now"" click on the button ""Index now""
-19. Verify indexing completed successfully 
+19. Verify indexing completed successfully
 
 ### Expected Results
 
-1. There is a module ""Open Y Search API"" and Search API Solr
-2. There is a server called ""Solr Search"" disabled by default 
-3. Server Configuration form is wotking without any issues 
-4. Search content idex present 
+1. There is a module ""YMCA Website Services Search API"" and Search API Solr
+2. There is a server called ""Solr Search"" disabled by default
+3. Server Configuration form is wotking without any issues
+4. Search content idex present
 5. Indexing content works without any issues
 
-## Verify search is working/Open Y search (Solr back-end)
+## Verify search is working/YMCA Website Services search (Solr back-end)
 
 ### User
 
@@ -68,14 +68,14 @@ Administrator / Anonymous
 
 ### Steps
 
-1. Go to the homepage 
-2. Verify there is a search icon that opens search form when you click on it 
+1. Go to the homepage
+2. Verify there is a search icon that opens search form when you click on it
 3. Enter some keywords,  for example: ymca; Swim Lessons, etc
-4. Verify you see results on the page 
-5. Find any landing page with some text on it and try to search by keywords from that landing page 
+4. Verify you see results on the page
+5. Find any landing page with some text on it and try to search by keywords from that landing page
 6. Verify search is working and show correct results
 
 ### Expected Results
 
-1. Search form is working 
+1. Search form is working
 2. Search results are correct

--- a/openy_search/openy_google_search/openy_google_search.info.yml
+++ b/openy_search/openy_google_search/openy_google_search.info.yml
@@ -3,7 +3,7 @@ type: module
 description: Provides a Google Custom search Engine for YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
 package: YMCA Website Services
-version: 8.x-1.0
+version: 1.1.0
 configure: openy_google_search.settings
 dependencies:
   - drupal:node

--- a/openy_search/openy_google_search/openy_google_search.info.yml
+++ b/openy_search/openy_google_search/openy_google_search.info.yml
@@ -1,8 +1,8 @@
-name: Open Y Google Search
+name: YMCA Website Services Google Search
 type: module
-description: Provides a Google Custom search Engine for Open Y.
+description: Provides a Google Custom search Engine for YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
-package: Open Y
+package: YMCA Website Services
 version: 8.x-1.0
 configure: openy_google_search.settings
 dependencies:

--- a/openy_search/openy_google_search/openy_google_search.links.menu.yml
+++ b/openy_search/openy_google_search/openy_google_search.links.menu.yml
@@ -1,6 +1,6 @@
 openy_google_search.admin:
   title: 'Google Search settings'
-  description: 'Configure Open Y Google Custom Search settings.'
+  description: 'Configure YMCA Website Services Google Custom Search settings.'
   parent: openy_system.openy_settings
   route_name: openy_google_search.settings
   weight: 100

--- a/openy_search/openy_google_search/openy_google_search.module
+++ b/openy_search/openy_google_search/openy_google_search.module
@@ -77,7 +77,7 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
  */
 function openy_google_search_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name == 'help.page.openy_google_search' || $route_name == 'openy_google_search.settings') {
-    return '<p>' . t('Read <a href="https://github.com/ymcatwincities/openy/blob/8.x-2.x/docs/Development/GoogleCustomSearchConfiguration.md">this topic</a> in Open Y online documentation to get information about Google Custom Search configuration.') . '</p>';
+    return '<p>' . t('Read our <a href="https://ds-docs.y.org/docs/development/googlecustomsearchconfiguration/" target="_blank">online documentation</a> to get information about Google Custom Search (aka Programmable Search) configuration.') . '</p>';
   }
 }
 

--- a/openy_search/openy_google_search/src/Form/SettingsForm.php
+++ b/openy_search/openy_google_search/src/Form/SettingsForm.php
@@ -68,12 +68,47 @@ class SettingsForm extends ConfigFormBase {
     $form['google_engine_id'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Google Search Engine ID'),
+      '#description' => $this->t('Go to the <a href="https://programmablesearchengine.google.com/controlpanel/all" target="_blank">Google Control Panel</a> then copy the ID from the search engine overview.'),
       '#size' => 40,
       '#default_value' => !empty($config->get('google_engine_id')) ? $config->get('google_engine_id') : '',
       '#required' => TRUE,
     ];
 
+    $form['search_page_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search page ID'),
+      '#description' => $this->t('Find the node id of the search results page by editing the page and looking in the URL for <code>/node/{node_id}/edit</code>'),
+      '#size' => 40,
+      '#default_value' => !empty($config->get('search_page_id')) ? $config->get('search_page_id') : '',
+      '#required' => TRUE,
+    ];
+
+    $form['search_query_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search query key'),
+      '#description' => $this->t('The argument preceding the search string in the URL. For example, in <code>/search?q=swim</code>, the query key is <code>q</code>. Google does not allow configuring this value.'),
+      '#size' => 40,
+      '#default_value' => !empty($config->get('search_query_key')) ? $config->get('search_query_key') : '',
+      '#required' => TRUE,
+      '#disabled' => 'disabled',
+    ];
+
     return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state)
+  {
+    $search_page_id = $form_state->getValue('search_page_id');
+
+    // Set an error if the page id is not a number.
+    if (!is_numeric($search_page_id)) {
+      $form_state
+        ->setErrorByName('search_page_id', $this
+        ->t('The Search page ID must be a number.'));
+    }
   }
 
   /**
@@ -83,6 +118,8 @@ class SettingsForm extends ConfigFormBase {
     $values = $form_state->getValues();
     $config = $this->config('openy_google_search.settings');
     $config->set('google_engine_id', $values['google_engine_id']);
+    $config->set('search_page_id', $values['search_page_id']);
+    $config->set('search_query_key', $values['search_query_key']);
     $config->save();
 
     $this->cacheTagsInvalidator->invalidateTags($config->getCacheTags());

--- a/openy_search/openy_google_search/src/Form/SettingsForm.php
+++ b/openy_search/openy_google_search/src/Form/SettingsForm.php
@@ -99,15 +99,14 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state)
-  {
+  public function validateForm(array &$form, FormStateInterface $form_state) {
     $search_page_id = $form_state->getValue('search_page_id');
 
     // Set an error if the page id is not a number.
     if (!is_numeric($search_page_id)) {
       $form_state
         ->setErrorByName('search_page_id', $this
-        ->t('The Search page ID must be a number.'));
+          ->t('The Search page ID must be a number.'));
     }
   }
 

--- a/openy_search/openy_google_search/src/OpenyGoogleSearchHelperService.php
+++ b/openy_search/openy_google_search/src/OpenyGoogleSearchHelperService.php
@@ -7,7 +7,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\path_alias\AliasManagerInterface;
 
 /**
- * Class OpenyGoogleSearchHelperService.
+ * Helper class for Google Search results page.
  */
 class OpenyGoogleSearchHelperService {
 
@@ -52,6 +52,7 @@ class OpenyGoogleSearchHelperService {
    * Gets alias for search results page id saved in module settings config.
    *
    * @return string
+   *   The url alias of the search page.
    */
   public function getSearchResultsPageAlias() {
     $language = $this->languageManager->getCurrentLanguage()->getId();

--- a/openy_search/openy_search.api.php
+++ b/openy_search/openy_search.api.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Alter the default Open Y themes search form parameters.
+ * Alter the default YMCA Website Services themes search form parameters.
  *
  * Search parameters for theme originally stored in theme_name.settings file.
  *

--- a/openy_search/openy_search.api.php
+++ b/openy_search/openy_search.api.php
@@ -15,7 +15,7 @@
  *
  * @see \Drupal\openy_search\Config\OpenySearchOverrides::loadOverrides()
  */
-function hook_openy_search_theme_configuration_alter(&$search_config) {
+function hook_openy_search_theme_configuration_alter(array &$search_config) {
   $search_config = [
     'search_query_key' => 'q',
     'search_page_alias' => 'search',

--- a/openy_search/openy_search.info.yml
+++ b/openy_search/openy_search.info.yml
@@ -1,6 +1,6 @@
-name: Open Y Search
+name: YMCA Website Services Search
 type: module
-description: Provides a classes and services for search modules in Open Y.
+description: Provides a classes and services for search modules in YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
-package: Open Y
+package: YMCA Website Services
 version: 8.x-1.0

--- a/openy_search/openy_search.info.yml
+++ b/openy_search/openy_search.info.yml
@@ -3,4 +3,4 @@ type: module
 description: Provides a classes and services for search modules in YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
 package: YMCA Website Services
-version: 8.x-1.0
+version: 1.1.0

--- a/openy_search/openy_search_api/config/install/views.view.search_content.yml
+++ b/openy_search/openy_search_api/config/install/views.view.search_content.yml
@@ -9,7 +9,7 @@ dependencies:
 id: search_content
 label: 'Content search'
 module: views
-description: 'Block to render content search results in Open Y Search API paragraph.'
+description: 'Block to render content search results in YMCA Website Services Search API paragraph.'
 tag: ''
 base_table: search_api_index_search_content
 base_field: search_api_id

--- a/openy_search/openy_search_api/openy_search_api.info.yml
+++ b/openy_search/openy_search_api/openy_search_api.info.yml
@@ -3,7 +3,7 @@ type: module
 description: Provides a Drupal Search API Engine for YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
 package: YMCA Website Services
-version: 8.x-1.0
+version: 1.1.0
 configure: openy_search_api.settings
 dependencies:
   - drupal:node

--- a/openy_search/openy_search_api/openy_search_api.info.yml
+++ b/openy_search/openy_search_api/openy_search_api.info.yml
@@ -4,6 +4,7 @@ description: Provides a Drupal Search API Engine for Open Y.
 core_version_requirement: ^8.8 || ^9 || ^10
 package: Open Y
 version: 8.x-1.0
+configure: openy_search_api.settings
 dependencies:
   - drupal:node
   - drupal:user

--- a/openy_search/openy_search_api/openy_search_api.info.yml
+++ b/openy_search/openy_search_api/openy_search_api.info.yml
@@ -1,8 +1,8 @@
-name: Open Y Search API
+name: YMCA Website Services Search API
 type: module
-description: Provides a Drupal Search API Engine for Open Y.
+description: Provides a Drupal Search API Engine for YMCA Website Services.
 core_version_requirement: ^8.8 || ^9 || ^10
-package: Open Y
+package: YMCA Website Services
 version: 8.x-1.0
 configure: openy_search_api.settings
 dependencies:

--- a/openy_search/openy_search_api/openy_search_api.install
+++ b/openy_search/openy_search_api/openy_search_api.install
@@ -45,7 +45,7 @@ function openy_search_api_install() {
       ->save();
   }
 
-  // Display message if Open Y installed.
+  // Display message if YMCA Website Services installed.
   if (\Drupal::moduleHandler()->moduleExists('openy_system')) {
     $url = Url::fromRoute('search_api.overview');
     $legacy = Url::fromRoute('system.modules_list', [], ['fragment' => 'module-search-api-solr-legacy']);

--- a/openy_search/openy_search_api/openy_search_api.links.menu.yml
+++ b/openy_search/openy_search_api/openy_search_api.links.menu.yml
@@ -1,0 +1,6 @@
+openy_search_api.admin:
+  title: 'Search API settings'
+  description: 'Configure Open Y Search API settings.'
+  parent: openy_system.openy_settings
+  route_name: openy_search_api.settings
+  weight: 100

--- a/openy_search/openy_search_api/openy_search_api.links.menu.yml
+++ b/openy_search/openy_search_api/openy_search_api.links.menu.yml
@@ -1,6 +1,6 @@
 openy_search_api.admin:
   title: 'Search API settings'
-  description: 'Configure Open Y Search API settings.'
+  description: 'Configure YMCA Website Services Search API settings.'
   parent: openy_system.openy_settings
   route_name: openy_search_api.settings
   weight: 100

--- a/openy_search/openy_search_api/openy_search_api.module
+++ b/openy_search/openy_search_api/openy_search_api.module
@@ -26,8 +26,15 @@ function openy_search_api_entity_view_alter(&$build, EntityInterface $entity, En
  * Implements hook_help().
  */
 function openy_search_api_help($route_name, RouteMatchInterface $route_match) {
-  if ($route_name == 'help.page.openy_search_api') {
-    return '<p>' . t('Read <a href="https://www.drupal.org/docs/8/modules/search-api">Search API online documentation</a> at Drupal.org to get information about Search configuration.') . '</p>';
+  if ($route_name == 'help.page.openy_search_api' || $route_name == 'openy_search_api.settings') {
+    return '<p>' .
+      t('Read our <a href="@dsdocs" target="_blank">documentation on enabling Solr site search</a> and the <a href="@dodocs" target="_blank">Drupal.org Search API online documentation</a> to get information about Search configuration.',
+        [
+          '@dsdocs' => 'https://ds-docs.y.org/docs/development/install-solr-site-search-for-open-y/',
+          '@dodocs' => 'https://www.drupal.org/docs/8/modules/search-api',
+        ]
+      )
+      . '</p>';
   }
 }
 

--- a/openy_search/openy_search_api/openy_search_api.routing.yml
+++ b/openy_search/openy_search_api/openy_search_api.routing.yml
@@ -1,0 +1,7 @@
+openy_search_api.settings:
+  path: '/admin/openy/settings/search-api'
+  defaults:
+    _form: '\Drupal\openy_search_api\Form\SettingsForm'
+    _title: 'Search API settings'
+  requirements:
+    _permission: 'administer search api'

--- a/openy_search/openy_search_api/src/Form/SettingsForm.php
+++ b/openy_search/openy_search_api/src/Form/SettingsForm.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\openy_search_api\Form;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings Form for openy_search_api.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * Constructs a \Drupal\openy_search_api\Form\SettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
+   *   The cache tag invalidator.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    $this->setConfigFactory($config_factory);
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('cache_tags.invalidator')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_search_api_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'openy_search_api.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('openy_search_api.settings');
+
+    $form['search_page_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search page ID'),
+      '#description' => $this->t('Find the node id of the search results page by editing the page and looking in the URL for <code>/node/{node_id}/edit</code>'),
+      '#size' => 40,
+      '#default_value' => !empty($config->get('search_page_id')) ? $config->get('search_page_id') : '',
+      '#required' => TRUE,
+    ];
+
+    $form['search_query_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search query key'),
+      '#description' => $this->t('The argument preceding the search string in the URL. For example, in <code>/search?q=swim</code>, the query key is <code>q</code>. Changing this also requires changing the View that is performing the search.'),
+      '#size' => 40,
+      '#default_value' => !empty($config->get('search_query_key')) ? $config->get('search_query_key') : '',
+      '#required' => TRUE,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state)
+  {
+    $search_page_id = $form_state->getValue('search_page_id');
+
+    // Set an error if the page id is not a number.
+    if (!is_numeric($search_page_id)) {
+      $form_state
+        ->setErrorByName('search_page_id', $this
+        ->t('The Search page ID must be a number.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $config = $this->config('openy_search_api.settings');
+    $config->set('search_page_id', $values['search_page_id']);
+    $config->set('search_query_key', $values['search_query_key']);
+    $config->save();
+
+    $this->cacheTagsInvalidator->invalidateTags($config->getCacheTags());
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/openy_search/openy_search_api/src/Form/SettingsForm.php
+++ b/openy_search/openy_search_api/src/Form/SettingsForm.php
@@ -89,15 +89,14 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state)
-  {
+  public function validateForm(array &$form, FormStateInterface $form_state) {
     $search_page_id = $form_state->getValue('search_page_id');
 
     // Set an error if the page id is not a number.
     if (!is_numeric($search_page_id)) {
       $form_state
         ->setErrorByName('search_page_id', $this
-        ->t('The Search page ID must be a number.'));
+          ->t('The Search page ID must be a number.'));
     }
   }
 


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-1254
- Update Google Search and Search API modules with config pages

To test:
- enable `openy_google_search` and `openy_search_api`
- Check `/admin/openy/settings/google-search`, try changing a setting, and save
- Check `/admin/openy/settings/search-api`, try changing a setting, and save
- See that the docs link to up-to-date places