### PR TITLE
fix: Cannot add Membership Calculator Block via Layout Builder

### DIFF
--- a/openy_calc/src/Form/CalcBlockForm.php
+++ b/openy_calc/src/Form/CalcBlockForm.php
@@ -122,7 +122,7 @@ class CalcBlockForm extends FormBase {
       '#theme' => 'openy_calc_form_header',
       '#steps' => $steps,
     ];
-    $header = $this->renderer->renderRoot($header);
+    $header = $this->renderer->render($header);
     $form['header'] = [
       '#markup' => $header,
     ];


### PR DESCRIPTION
Resolves https://yusa.atlassian.net/browse/DS-1297

> When I try to add the Membership Calculator Block, nothing happens, the button spins and I can't see the block added to the page.
> Upon inspecting the error, I see a 500 returned in the Network tab with this message

```
<em class="placeholder">LogicException</em>
: A stray renderRoot() invocation is causing bubbling of attached assets to break. in <em class="placeholder">Drupal\Core\Render\Renderer-&gt;renderRoot()</em>
(line <em class="placeholder">142</em>
of <em class="placeholder">core/lib/Drupal/Core/Render/Renderer.php</em>
). <pre class="backtrace">Drupal\openy_calc\Form\CalcBlockForm-&gt;buildForm(Array, Object)
call_user_func_array(Array, Array) (Line: 536)
Drupal\Core\Form\FormBuilder-&gt;retrieveForm(&#039;calc_block_form &#039;, Object) (Line: 283)
Drupal\Core\Form\FormBuilder-&gt;buildForm(&#039;Drupal\openy_calc\Form\CalcBlockForm &#039;, Object) (Line: 224)
Drupal\Core\Form\FormBuilder-&gt;getForm(&#039;Drupal\openy_calc\Form\CalcBlockForm &#039;) (Line: 61)
Drupal\openy_calc\Plugin\Block\CalcBlock-&gt;build() (Line: 117)
Drupal\layout_builder\EventSubscriber\BlockComponentRenderArray-&gt;onBuildRender(Object, &#039;section_component.build.render_array &#039;, Object)
call_user_func(Array, Object, &#039;section_component.build.render_array &#039;, Object) (Line: 111)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher-&gt;dispatch(Object, &#039;section_component.build.render_array &#039;) (Line: 90)
Drupal\layout_builder\SectionComponent-&gt;toRenderArray(Array, 1) (Line: 88)
Drupal\layout_builder\Section-&gt;toRenderArray(Array, 1) (Line: 228)
Drupal\layout_builder\Element\LayoutBuilder-&gt;buildAdministrativeSection(Object, 1) (Line: 112)
Drupal\layout_builder\Element\LayoutBuilder-&gt;layout(Object) (Line: 86)
Drupal\layout_builder\Element\LayoutBuilder-&gt;preRender(Array)
call_user_func_array(Array, Array) (Line: 101)
Drupal\Core\Render\Renderer-&gt;doTrustedCallback(Array, Array, &#039;Render #pre_render callbacks must be methods of a class that implements \Drupal\Core\Security\TrustedCallbackInterface or be an anonymous function. The callback was %s. See https://www.drupal.org/node/2966725 &#039;, &#039;exception &#039;, &#039;Drupal\Core\Render\Element\RenderCallbackInterface &#039;) (Line: 788)
Drupal\Core\Render\Renderer-&gt;doCallback(&#039;#pre_render &#039;, Array, Array) (Line: 374)
Drupal\Core\Render\Renderer-&gt;doRender(Array, 1) (Line: 204)
Drupal\Core\Render\Renderer-&gt;render(Array, 1) (Line: 148)
```