### PR TITLE
Add isset check to isEmpty in CustomHoursItem.php

### DIFF
--- a/openy_field_hours/modules/openy_field_custom_hours/src/Plugin/Field/FieldType/CustomHoursItem.php
+++ b/openy_field_hours/modules/openy_field_custom_hours/src/Plugin/Field/FieldType/CustomHoursItem.php
@@ -70,7 +70,7 @@ class CustomHoursItem extends FieldItemBase implements FieldItemInterface {
    */
   public function isEmpty() {
     $values = $this->getValue();
-    if ($values['hours_label'] !== '') {
+    if (isset($values['hours_label']) && $values['hours_label'] !== '') {
       return FALSE;
     }
     return TRUE;


### PR DESCRIPTION
Resolves an issue on `/admin/structure/types/manage/branch/display/full/layout` where this error is thrown:

> Warning: Undefined array key "hours_label" in Drupal\openy_field_custom_hours\Plugin\Field\FieldType\CustomHoursItem->isEmpty() (line 73 of modules/contrib/openy_custom/openy_field_hours/modules/openy_field_custom_hours/src/Plugin/Field/FieldType/CustomHoursItem.php).
Drupal\openy_field_custom_hours\Plugin\Field\FieldType\CustomHoursItem->isEmpty() (Line: 255)