### PR TITLE
Support Domain Access

### DIFF
--- a/openy_search/src/Config/OpenySearchOverrides.php
+++ b/openy_search/src/Config/OpenySearchOverrides.php
@@ -44,7 +44,20 @@ class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
    * {@inheritdoc}
    */
   public function loadOverrides($names) {
-    $default_theme = $this->configFactory->getEditable('system.theme')->getOriginal('default');
+    $default_theme = NULL;
+    if (\Drupal::hasService('domain.negotiator')) {
+      /* @var \Drupal\domain\DomainNegotiatorInterface $domain_negotiator */
+      $domain_negotiator = \Drupal::service('domain.negotiator');
+      if (!is_null($domain_negotiator->getActiveDomain())) {
+        if ($active = \Drupal::service('domain.negotiator')->getActiveId()) {
+          $default_theme = $this->configFactory->getEditable('domain.config.' . $active . '.system.theme')
+            ->getOriginal('default');
+        }
+      }
+    }
+    if (!$default_theme) {
+      $default_theme = $this->configFactory->getEditable('system.theme')->getOriginal('default');
+    }
     $overrides = [];
     if (in_array($default_theme . '.settings', $names)) {
       // Allow other modules to alter the theme search configuration.


### PR DESCRIPTION
If Domain Access is enabled and the theme is overridden in Domain Config settings, the search block query string is not passed correctly. This checks if Domain is available and pulls the correct config if so.

Pulled some work from https://www.drupal.org/project/color/issues/3271369.