### PR TITLE
fix: remove circular yusaopeny require from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,6 @@
   "name": "open-y-subprojects/openy_custom",
   "description": "Custom core modules for Open Y distrubution.",
   "type": "drupal-module",
-  "require": {
-    "ycloudyusa/yusaopeny": "> 11.1.0.0"
-  },
   "license": "GPL-2.0+",
   "minimum-stability": "dev"
 }


### PR DESCRIPTION
## Summary
- Removes `"ycloudyusa/yusaopeny": "> 11.1.0.0"` from `require` in composer.json
- This is a circular dependency (yusaopeny profile already requires openy_custom)
- The constraint breaks PR builder: dev branches lack numeric versions, so composer silently downgrades openy_custom to 3.0.4

## Context
- PR builder log: https://logs-pr.cibox.tools/350/code-build.html
- Composer wildcard `dev-*` constraints are not supported ([composer/composer#7847](https://github.com/composer/composer/issues/7847))
- Removing the require is the cleanest fix since the profile controls the dependency direction